### PR TITLE
Discover git repositories in parent folders

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,46 @@
+# Set up the build environment.
+environment:
+  matrix:
+    - channel: stable
+      target: x86_64-pc-windows-msvc
+    - channel: beta
+      target: x86_64-pc-windows-msvc
+    - channel: nightly
+      target: x86_64-pc-windows-msvc
+
+# Allow for occasional compiler breakage on nightly Rust.
+matrix:
+  fast_finish: true
+  allow_failures:
+    - channel: nightly
+
+# Set up the Rust toolchain.
+install:
+  - set PATH=C:\Program Files\Git\mingw64\bin;%PATH%
+  - curl -fsS "https://win.rustup.rs/" -o rustup-init.exe
+  - rustup-init.exe -y --default-toolchain %channel%-%target%
+  - set PATH=%PATH%;C:\Users\appveyor\.cargo\bin
+  - rustc -V
+  - cargo -V
+
+# Build the Bors staging and trying branches, plus PRs to develop, master, and
+# the latest release branch.
+branches:
+  only:
+    - staging
+    - trying
+    - develop
+    - master
+    - /release-.*/
+
+# Force third-party crates to persist from previous builds and update only when
+# needed.
+cache:
+  - .cargo -> rust-%channel%-date, cargo-%channel%-build
+
+# Since this is not a .NET project, we can flip the build system off.
+build: false
+
+# Generate documentation, compile the engine, run tests.
+test_script:
+  - cargo test --all -v

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,7 +120,7 @@ dependencies = [
 
 [[package]]
 name = "glit"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "ansi_term 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.29.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glit"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Gwen Lofman <Gwen@Lofman.io>"]
 description = "A utility for pretty-printing git stats"
 license = "MPL-2.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -213,14 +213,14 @@ fn main() {
         let error: Result<(), ProgramErr> = match Mode::from_matches(&matches) {
             // Determine whether the given path is a git repository
             Mode::IsRepo(path) => {
-                match Repository::open(path) {
+                match Repository::discover(path) {
                     Ok(_) => Ok(()),
                     Err(_) => Err(BadPath(Box::new(path))),
                 }
             },
             // Parse pretty format and insert git status
             Mode::Glitter{ path, format } => {
-                match Repository::open(path) {
+                match Repository::discover(path) {
                     Ok(mut repo) => {
                         let parse = parser::expression_tree(format.as_bytes()).to_result();
                         match parse {


### PR DESCRIPTION
Previously, would not discover a git repository in a parent folder, breaking functionality if the user entered a sub-directory because of the behaviour of [`git2::Repository::open`].

Uses the [`git2::Repository::discover`] static method to create a git repository to enable discovery of parent git repositories.

Solves #4 

[`git2::Repository::open`]: https://docs.rs/git2/0.6.8/git2/struct.Repository.html#method.open
[`git2::Repository::discover`]: https://docs.rs/git2/0.6.8/git2/struct.Repository.html#method.discover