### PR TITLE
Use branch name shorthand

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -96,7 +96,7 @@ impl Stats {
     fn read_branch(&mut self, repo: &Repository) {
         self.branch = match repo.head() {
             Ok(head) => {
-                if let Some(name) = head.name() {
+                if let Some(name) = head.shorthand() {
                     // try to use first 8 characters or so of the ID in detached HEAD
                     if name == "HEAD" {
                         if let Ok(commit) = head.peel_to_commit() {
@@ -110,7 +110,7 @@ impl Stats {
                         }
                     // Grab the branch from the reference
                     } else {
-                        let branch = name.split("/").last().unwrap_or("").to_string();
+                        let branch = name.to_string();
                         // Since we have a branch name, look for the name of the upstream branch
                         self.read_upstream_name(repo, &branch);
                         branch


### PR DESCRIPTION
# Broken behaviour

Previous branch name required manual parsing to find the name at the end of the full reference by splitting on the backslash; however, this breaks if there are `/` in the name of the branch since `/` was use to split the full reference and take the last element.

Using `/` in branch names is a practice sometimes used to group relevant types of issues together in a readable and clear way.  Because the branch name is broken, all of the upstream related functionality also breaks when the branch name is improperly parsed.

![broken_branchname](https://user-images.githubusercontent.com/14112725/36035738-c923127a-0d85-11e8-8112-bdb870cab8e9.gif)

# Replication

On **Glitter** version `0.1.1` or lower:

```
$ mkdir repo
$ cd repo
$ git init
$ git co -b "bug/demonstrate"
$ glit "\b\B('..')"
```

# Fix

`git2` has the [`git2::Reference::shorthand`] API call to solve this issue, which removes the need to manually parse the name, making branch name and upstream name robust to backslashes in the name of the repository.

![fix-branch-name](https://user-images.githubusercontent.com/14112725/36036260-6ae7e710-0d87-11e8-9414-9dc7b6cb9ef7.png)

[`git2::Reference::shorthand`]: https://docs.rs/git2/0.6.8/git2/struct.Reference.html#method.shorthand