### PR TITLE
Clarify parser invariance test name

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -435,7 +435,7 @@ mod test {
     use super::*;
 
     quickcheck! {
-        fn disp_parse_idempotent(expect: Expression) -> bool {
+        fn disp_parse_invariant(expect: Expression) -> bool {
             let test = format!("{}", expect);
             println!("{} from {:?}", test, expect);
             let parse = expression(test.as_bytes());


### PR DESCRIPTION
The test which parses the disp output to see if the ASTs are the same is actually an invariance test which ensures the AST and the parser keep in line with each-other.