### PR TITLE
Apply a patch to rust-ansi-term to fix line wrap issue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,7 +16,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "ansi_term"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/glfmn/rust-ansi-term?branch=escape_sequence#22f4a231ed70ad45c8879f52dde56eca4ca84c69"
 dependencies = [
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -246,7 +246,7 @@ dependencies = [
 name = "glit"
 version = "0.1.4"
 dependencies = [
- "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ansi_term 0.11.0 (git+https://github.com/glfmn/rust-ansi-term?branch=escape_sequence)",
  "clap 2.29.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "criterion 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "git2 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -849,7 +849,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [metadata]
 "checksum aho-corasick 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "1e9a933f4e58658d7b12defcf96dc5c720f20832deebe3e0a19efd3b6aaeeb9e"
 "checksum ansi_term 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6b3568b48b7cefa6b8ce125f9bb4989e52fbcc29ebea88df04cc7c5f12f70455"
-"checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+"checksum ansi_term 0.11.0 (git+https://github.com/glfmn/rust-ansi-term?branch=escape_sequence)" = "<none>"
 "checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
 "checksum backtrace 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "89a47830402e9981c5c41223151efcced65a0510c13097c769cede7efb34782a"
 "checksum backtrace-sys 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)" = "c66d56ac8dabd07f6aacdaf633f4b8262f5b3601a810a0dcddffd5c22c69daa0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,9 @@ git2 = "0.9"
 ansi_term = "0.11"
 nom = "^3.2"
 
+[patch.crates-io]
+ansi_term = { git = "https://github.com/glfmn/rust-ansi-term", branch = "escape_sequence" }
+
 [dev-dependencies]
 proptest = "0.8.6"
 criterion = "0.2"


### PR DESCRIPTION
Manually add escapes to code which prints color sequences; the problem is that these sequences are only properly interpreted in the shell prompt and are printed as the weird block-y unicode things when they appear in _any_ other context.  As a result, this is only a temporary fix while I look into better methods of adding the escapes conditionally, perhaps using command-line options.

Fixes #10.

![fixed](https://user-images.githubusercontent.com/14112725/60200115-766a7680-9813-11e9-8cb3-4af39ffb2ad4.gif)
